### PR TITLE
Wall pushback

### DIFF
--- a/game/player/Player.gd
+++ b/game/player/Player.gd
@@ -53,7 +53,7 @@ var current_hitstop_tick: int
 
 var hitstun_duration: int
 var pushback: int
-var pushback_from: Object
+var pushback_from: String
 
 var attack_id: int
 var hit_by: Dictionary
@@ -182,7 +182,7 @@ func receive_hit(attack_data: AttackData, attack_owner: Object) -> void:
     hitstop_duration = attack_data.hitstop
     current_hitstop_tick = 0
     pushback = attack_data.pushback
-    pushback_from = attack_owner
+    pushback_from = attack_owner.name
     health -= attack_data.damage
     SyncManager.play_sound("%s_%s" % [name, attack_owner.attack_id], attack_data.sound_effect)
     
@@ -302,7 +302,7 @@ func _network_spawn_preprocess(data: Dictionary) -> Dictionary:
     data['hst'] = spawn_hitstop
     data['hsu'] = spawn_hitstop
     data['pb'] = spawn_velocity
-    data['pbf'] = null
+    data['pbf'] = ""
     data['v'] = spawn_velocity
     data['a'] = initial_attack_id
     data['hb'] = var_to_bytes({})

--- a/game/player/attack/AttackData.gd
+++ b/game/player/attack/AttackData.gd
@@ -1,6 +1,5 @@
 class_name AttackData extends Resource
 
-var attack_id: int
 @export var damage: int
 @export var hitstun: int
 @export var hitstop: int
@@ -8,20 +7,26 @@ var attack_id: int
 @export var sound_effect: AudioStream
 var num_hits: int = 1
 
-static func combine_overlapping_attacks(accumulator: AttackData, real: AttackData) -> AttackData:
+static func combine_overlapping_attacks(accumulator_array: Array, real_array: Array) -> Array:
+    var accumulator = accumulator_array[0]
+    var real = real_array[0]
+    var real_owner = real_array[1]
+
     var acc_total = accumulator.hitstun + accumulator.hitstop
     var real_total = real.hitstun + real.hitstop
     if real_total > acc_total:
         accumulator.hitstop = real.hitstop
         accumulator.hitstun = real.hitstun
         accumulator.pushback = real.pushback
+        accumulator_array[1] = real_owner
     elif real_total == acc_total:
         if real.hitstun > accumulator.hitstun:
             accumulator.hitstop = real.hitstop
             accumulator.hitstun = real.hitstun
             accumulator.pushback = real.pushback
+            accumulator_array[1] = real_owner
     
     accumulator.damage += real.damage
     accumulator.num_hits += real.num_hits
 
-    return accumulator
+    return accumulator_array

--- a/game/player/fsm/effects/EffectLib.gd
+++ b/game/player/fsm/effects/EffectLib.gd
@@ -99,7 +99,7 @@ static func decaying_pushback(owner: Player, _input: Dictionary, ticks_in_state:
     var remainder = owner.pushback % min(owner.hitstun_duration, 10)
     base_decay += min(ticks_in_state, remainder)
 
-    owner.velocity = owner.scale.x * -1 * max(owner.pushback - base_decay, 0)
+    owner.pushback_velocity = owner.scale.x * -1 * max(owner.pushback - base_decay, 0)
     #if ticks_in_state % 3 != 0:
         #owner.pushback = max(owner.pushback - 2, 0)
         

--- a/game/resolver/InteractionResolver.gd
+++ b/game/resolver/InteractionResolver.gd
@@ -43,10 +43,11 @@ func _resolve_player_movement() -> void:
     # if a player is past edge and has pushback also in that direction, apply pushback to their attacker.
     for player in players:
         var predicted_x = player.position.x + player.pushback_velocity
-        if player.pushback_from is Player and (\
+        var player_attackers = players.filter(func(x): return x.name == player.pushback_from)
+        if not player_attackers.is_empty() and player_attackers[0] is Player and (\
                 (predicted_x <= min_x and player.pushback_velocity < 0) \
                 or (predicted_x >= max_x and player.pushback_velocity > 0)):
-            _apply_reversed_pushback(player)
+            _apply_reversed_pushback(player, player_attackers[0])
     
     for player in players:
         # Apply pushback now that calculations are done
@@ -54,8 +55,7 @@ func _resolve_player_movement() -> void:
         # Clamp player x values to stay within stage boundaries
         _restrict_player_x(player)
 
-func _apply_reversed_pushback(pushed_player: Player) -> void:
-    var attacker = pushed_player.pushback_from
+func _apply_reversed_pushback(pushed_player: Player, attacker: Player) -> void:
     if attacker.pushback_velocity != 0:
         attacker.pushback_velocity = attacker.pushback_velocity
     else:


### PR DESCRIPTION
A lil' hacky with the implementation, partially because attackData is a resource that's going to be cached and shared. There are lots of ways to do it better, but it's functional enough for now.

For logic, I checked the apparent design of GG +R and SF6. Both look like they start applying pushback to the attacker as soon as the defender comes up against the wall.

This doesn't address airborne / juggle states, which tend to ignore this rule, I think? There are probably ways this can break down, but I'm fine with using this basic strategy for now.