### PR TITLE
Pushbox and crossup

### DIFF
--- a/game/TestGameplay.gd
+++ b/game/TestGameplay.gd
@@ -76,11 +76,6 @@ func _on_sync_started():
     else:
         fighterP2.input_retriever = match_options.input_retrievers[1]
 
-    fighterP2.hurtbox_pool.collision_layer = 8
-    fighterP2.hurtbox_pool.collision_mask = 4
-    fighterP2.hitbox_pool.collision_layer = 2
-    fighterP2.hitbox_pool.collision_mask = 1
-    fighterP2.scale.x = -1
     health_tracker_2.tracked_player = fighterP2
     combo_counter_2.tracked_player = fighterP2
     fighterP2.defeated.connect(_on_player_defeated)

--- a/game/TestGameplay.tscn
+++ b/game/TestGameplay.tscn
@@ -112,5 +112,6 @@ parameters/looping = true
 script = ExtResource("7_1ckhu")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+z_index = -100
 position = Vector2(0, 300)
 texture = ExtResource("8_7iqk1")

--- a/game/options/MatchOptions.gd
+++ b/game/options/MatchOptions.gd
@@ -1,5 +1,7 @@
 class_name MatchOptions extends RefCounted
 
+const separate_distance: int = 10
+
 var input_retrievers: Array
 
 func _init(new_input_retrievers):

--- a/game/player/Player.gd
+++ b/game/player/Player.gd
@@ -20,6 +20,8 @@ signal defeated
     # pb - pushback
     # pbf - pushback from (other player, etc.)
     # v - velocity
+    # fd - facing direction
+    # sx - scale x (for actual facing)
     # a - attack id
     # ah - attack hit
     # hb - hit by
@@ -49,6 +51,7 @@ var team: Side
 var character: Characters
 var health: int
 var velocity: int
+var facing_direction: Side
 
 var previous_input: int
 var status: Status
@@ -249,6 +252,8 @@ func _save_state() -> Dictionary:
         'pb': pushback,
         'pbf': pushback_from,
         'v': velocity,
+        'fd': facing_direction,
+        'sx': scale.x,
         'a': attack_id,
         'ah': attack_hit,
         'hb': var_to_bytes(hit_by),
@@ -268,6 +273,8 @@ func _load_state(state: Dictionary) -> void:
     pushback = state['pb']
     pushback_from = state['pbf']
     velocity = state['v']
+    facing_direction = state['fd']
+    scale.x = state['sx']
     attack_id = state['a']
     attack_hit = state['ah']
     hit_by = bytes_to_var(state['hb'])
@@ -348,6 +355,8 @@ func _network_spawn_preprocess(data: Dictionary) -> Dictionary:
     data['pb'] = spawn_velocity
     data['pbf'] = ""
     data['v'] = spawn_velocity
+    data['fd'] = Player.Side.P1 if sign(position.x) < 0 else Player.Side.P2
+    data['sx'] = get_side_scale(facing_direction)
     data['a'] = initial_attack_id
     data['ah'] = false
     data['hb'] = var_to_bytes({})
@@ -376,6 +385,9 @@ enum Side {
     P1 = 0,
     P2 = 1
 }
+
+static func get_side_scale(side: Side) -> int:
+    return 1 if side == Side.P1 else -1
 
 enum Characters {
     SPEED = 0,

--- a/game/player/Player.tscn
+++ b/game/player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bqflbbnh7mpr4"]
+[gd_scene load_steps=14 format=3 uid="uid://bqflbbnh7mpr4"]
 
 [ext_resource type="Script" path="res://player/Player.gd" id="1_477q8"]
 [ext_resource type="Texture2D" uid="uid://bl34rh555skbp" path="res://assets/art/placeholder_character_sheet.png" id="2_xguty"]
@@ -135,6 +135,9 @@ _data = {
 "walk": SubResource("Animation_btqih")
 }
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_nfot4"]
+size = Vector2(48, 128)
+
 [node name="Player" type="Node2D"]
 script = ExtResource("1_477q8")
 
@@ -176,3 +179,8 @@ libraries = {
 autoplay = "idle"
 playback_auto_capture = false
 script = ExtResource("4_cqwil")
+
+[node name="Pushbox" parent="." instance=ExtResource("3_upa8i")]
+visible = true
+shape = SubResource("RectangleShape2D_nfot4")
+draw_color = Color(0, 0.940033, 0.967931, 1)

--- a/game/player/fsm/FsmState.gd
+++ b/game/player/fsm/FsmState.gd
@@ -8,6 +8,9 @@ class_name FsmState extends Resource
 @export var animation_key: String = ""
 
 func transition_in(owner: Player, input: Dictionary) -> void:
+    # default behavior - change facing when entering a new state.
+    EffectLib.match_scale_to_facing(owner, input, 0)
+    
     # apply all one-time phase effects to do when transitioning into the state.
     for effect in transition_in_effects:
         const ticks_in_state = 0

--- a/game/player/fsm/effects/EffectLib.gd
+++ b/game/player/fsm/effects/EffectLib.gd
@@ -15,6 +15,7 @@ enum Effect {
     DECAYING_PUSHBACK = 7,
     VELOCITY_DECAY_NATURAL = 8,
     PLAY_SOUND = 9,
+    MATCH_SCALE_TO_FACING = 10,
 }
 
 static var methods := {
@@ -28,6 +29,7 @@ static var methods := {
     Effect.DECAYING_PUSHBACK: decaying_pushback,
     Effect.VELOCITY_DECAY_NATURAL: velocity_decay_natural,
     Effect.PLAY_SOUND: play_sound,
+    Effect.MATCH_SCALE_TO_FACING: match_scale_to_facing,
 }
 
 
@@ -115,5 +117,10 @@ static func velocity_decay_natural(owner: Player, _input: Dictionary, _ticks_in_
 
 static func play_sound(owner: Player, _input: Dictionary, _ticks_in_state: int, sound_effect: AudioStream) -> Player.State:
     SyncManager.play_sound("%s_effectLib_%s" % [owner.name, sound_effect.resource_name], sound_effect)
+
+    return Player.State.NONE
+
+static func match_scale_to_facing(owner: Player, _input: Dictionary, _ticks_in_state: int) -> Player.State:
+    owner.scale.x = Player.get_side_scale(owner.facing_direction)
 
     return Player.State.NONE

--- a/game/resolver/InteractionResolver.gd
+++ b/game/resolver/InteractionResolver.gd
@@ -41,6 +41,16 @@ func _on_player_processing_complete() -> void:
 func _resolve_player_movement() -> void:
     var players = [p1, p2]
 
+    # separate players if pushboxes overlap
+    var overlap_distance = Player.get_overlap_x_distance(p1.pushbox, p2.pushbox)
+    if overlap_distance > 0:
+        # whoever has the higher magnitude of distance gets the extra bit of push
+        var separate_distance = min(overlap_distance / 2, MatchOptions.separate_distance)
+        var remainder = overlap_distance % 2
+        players.sort_custom(func(a, b): return abs(a.position.x) > abs(b.position.x))
+        players[0].position.x += (separate_distance + remainder) * sign(players[0].position.x)
+        players[1].position.x += separate_distance * -1 * sign(players[0].position.x)
+
     # if a player is past edge and has pushback also in that direction, apply pushback to their attacker.
     for player in players:
         var predicted_x = player.position.x + player.pushback_velocity

--- a/game/resolver/InteractionResolver.gd
+++ b/game/resolver/InteractionResolver.gd
@@ -66,8 +66,20 @@ func _resolve_player_movement() -> void:
         # Clamp player x values to stay within camera boundaries
         _restrict_player_x(player)
 
+    # update player's side information based on position. It's up to player when to fix their scale.
+    if p1.position.x < p2.position.x:
+        p1.facing_direction = 0
+        p2.facing_direction = 1
+    else:
+        p1.facing_direction = 1
+        p2.facing_direction = 0
     # Camera position will be set in CameraControl's post-process
-
+    
+    for player in players:
+        if player.status == Player.Status.NEUTRAL:
+            player.scale.x = Player.get_side_scale(player.facing_direction)
+        
+    
 func _restrict_player_x(player: Player):
     player.position.x = camera_control.clamp_to_logical_camera(player.position.x, player.width)
 
@@ -88,12 +100,6 @@ func _adjudicate_interactions(actors: Array) -> void:
     # For each player, check if their hurtbox pool got hit.
     #  This will replace the "successful hit" status for them
     # for each successful collision, apply damage to the other player.
-    if p1.position.x > p2.position.x:
-        p1.scale.x = -1
-        p2.scale.x = 1
-    elif p1.position.x < p2.position.x:
-        p1.scale.x = 1
-        p2.scale.x = -1
 
     # get all hitboxes, sort by allegiance.
     var p1_attack_shapes: Array = []


### PR DESCRIPTION
adds concept of pushbox & nicer turnaround logic.

Pushbox is pretty limited for now - just use basic logic to separate player 1 & 2 when they overlap with their singular pushbox.

Turnaround logic matters less now, since there's no jumping planned yet. Big change is that the player doesn't turn around mid-action. They turn automatically during any idle frame, or turn when transitioning between states.

There's no fancy "turning transition animation" supported or planned in this system, but it probably is feasible to hack it on somehow.