### PR TITLE
Handle desync

### DIFF
--- a/game/SceneSwitchUtil.gd
+++ b/game/SceneSwitchUtil.gd
@@ -1,0 +1,11 @@
+class_name SceneSwitchUtil
+
+static var main_menu_scene: PackedScene = preload("res://network/main.tscn")
+
+static func change_scene(tree: SceneTree, new_root: Node) -> void:
+    var old_root = tree.current_scene
+    tree.root.add_child(new_root)
+    tree.current_scene = new_root
+    
+    new_root.get_viewport().canvas_transform = Transform2D.IDENTITY
+    old_root.queue_free()

--- a/game/TestGameplay.gd
+++ b/game/TestGameplay.gd
@@ -51,12 +51,13 @@ func _ready():
         var receiver_side = client_side if multiplayer.is_server() else host_side
         SyncManager.message_serializer.produce_input_path = "%s/fighter%s" % [get_path(), producer_side]
         SyncManager.message_serializer.receive_input_path = "%s/fighter%s" % [get_path(), receiver_side]
+        for id in [p1_network_id, p2_network_id]:
+            if id != multiplayer.get_unique_id():
+                SyncManager.add_peer(id)
     else:
         SyncManager.set_network_adaptor(preload("res://addons/godot-rollback-netcode/DummyNetworkAdaptor.gd").new())
 
-    for id in [p1_network_id, p2_network_id]:
-        if id != multiplayer.get_unique_id():
-            SyncManager.add_peer(id)
+    
     
     # SyncManager.start_logging("D:/detailed_logs/logfile_%s" % multiplayer.get_unique_id())
     
@@ -123,6 +124,8 @@ func _close_rollback_networking():
 
 func _return_to_network_menu() -> void:
     print_debug("I'm returning to the network menu!")
+    var main_menu_scene = SceneSwitchUtil.main_menu_scene.instantiate()
+    SceneSwitchUtil.change_scene(get_tree(), main_menu_scene)
     pass # return to network menu
 
 func _on_sync_stopped(reason: Disconnect.Reason):

--- a/game/TestGameplay.tscn
+++ b/game/TestGameplay.tscn
@@ -157,3 +157,6 @@ script = ExtResource("7_1ckhu")
 z_index = -100
 position = Vector2(0, 300)
 texture = ExtResource("8_7iqk1")
+
+[node name="StartMatchTimer" type="Timer" parent="."]
+one_shot = true

--- a/game/TestGameplay.tscn
+++ b/game/TestGameplay.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bmufwtv6hw8ys"]
+[gd_scene load_steps=14 format=3 uid="uid://bmufwtv6hw8ys"]
 
 [ext_resource type="Script" path="res://TestGameplay.gd" id="1_hel5h"]
 [ext_resource type="PackedScene" uid="uid://dv55emdwbx4m0" path="res://ui/HealthTracker.tscn" id="2_cvjpa"]
@@ -12,6 +12,7 @@
 [ext_resource type="Script" path="res://resolver/CameraControl.gd" id="7_1ckhu"]
 [ext_resource type="Texture2D" uid="uid://c3l0vjui7midg" path="res://assets/art/background.png" id="8_7iqk1"]
 [ext_resource type="PackedScene" uid="uid://cnrgtvljl7jnx" path="res://ui/SpecialCounter.tscn" id="8_iinh3"]
+[ext_resource type="PackedScene" uid="uid://bdy1yk1bvbqwg" path="res://ui/menu/Notification.tscn" id="9_rb1s8"]
 
 [node name="TestGameplay" type="Node2D"]
 script = ExtResource("1_hel5h")
@@ -121,6 +122,20 @@ offset_top = 0.0
 offset_bottom = 34.0
 grow_vertical = 1
 
+[node name="Notification" parent="UI" instance=ExtResource("9_rb1s8")]
+visible = false
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -177.0
+offset_top = -63.5
+offset_right = 177.0
+offset_bottom = 63.5
+grow_horizontal = 2
+grow_vertical = 2
+
 [node name="ConfirmDefeatTimer" type="Node" parent="."]
 script = ExtResource("3_7unwa")
 one_shot = true
@@ -138,7 +153,7 @@ parameters/looping = true
 [node name="CameraControl" type="Node2D" parent="."]
 script = ExtResource("7_1ckhu")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="Background" type="Sprite2D" parent="."]
 z_index = -100
 position = Vector2(0, 300)
 texture = ExtResource("8_7iqk1")

--- a/game/addons/godot-rollback-netcode/DummyNetworkAdaptor.gd
+++ b/game/addons/godot-rollback-netcode/DummyNetworkAdaptor.gd
@@ -3,28 +3,28 @@ extends "res://addons/godot-rollback-netcode/NetworkAdaptor.gd"
 var my_peer_id: int
 
 func _init(_my_peer_id: int = 1) -> void:
-	my_peer_id = _my_peer_id
+    my_peer_id = _my_peer_id
 
 func send_ping(peer_id: int, msg: Dictionary) -> void:
-	pass
+    pass
 
 func send_ping_back(peer_id: int, msg: Dictionary) -> void:
-	pass
+    pass
 
 func send_remote_start(peer_id: int) -> void:
-	pass
+    pass
 
-func send_remote_stop(peer_id: int) -> void:
-	pass
+func send_remote_stop(peer_id: int, reason: Disconnect.Reason = Disconnect.Reason.UNKNOWN) -> void:
+    pass
 
 func send_input_tick(peer_id: int, msg: PackedByteArray) -> void:
-	pass
+    pass
 
 func is_network_host() -> bool:
-	return my_peer_id == 1
+    return my_peer_id == 1
 
 func is_network_master_for_node(node: Node) -> bool:
-	return node.get_multiplayer_authority() == my_peer_id
+    return node.get_multiplayer_authority() == my_peer_id
 
 func get_unique_id() -> int:
-	return my_peer_id
+    return my_peer_id

--- a/game/addons/godot-rollback-netcode/NakamaWebRTCNetworkAdaptor.gd
+++ b/game/addons/godot-rollback-netcode/NakamaWebRTCNetworkAdaptor.gd
@@ -16,12 +16,12 @@ var max_duplicate_msecs := 100
 var max_packet_lifetime := 66
 
 class MessageHash:
-	var value: int
-	var time: int
+    var value: int
+    var time: int
 
-	func _init(_value: int, _time: int) -> void:
-		value = _value
-		time = _time
+    func _init(_value: int, _time: int) -> void:
+        value = _value
+        time = _time
 
 var _data_channels := {}
 var _last_messages := {}
@@ -30,138 +30,138 @@ var _last_skipped_tick := 0
 var _skipped_tick_count := 0
 
 func attach_network_adaptor(sync_manager) -> void:
-	if OnlineMatch:
-		OnlineMatch.webrtc_peer_added.connect(self._on_OnlineMatch_webrtc_peer_added)
-		OnlineMatch.webrtc_peer_removed.connect(self._on_OnlineMatch_webrtc_peer_removed)
-		OnlineMatch.disconnected.connect(self._on_OnlineMatch_disconnected)
-		OnlineMatch.match_left.connect(self._on_OnlineMatch_match_left)
-	else:
-		push_error("Can't find OnlineMatch singleton that the NakamaWebRTCNetworkAdaptor depends on!")
+    if OnlineMatch:
+        OnlineMatch.webrtc_peer_added.connect(self._on_OnlineMatch_webrtc_peer_added)
+        OnlineMatch.webrtc_peer_removed.connect(self._on_OnlineMatch_webrtc_peer_removed)
+        OnlineMatch.disconnected.connect(self._on_OnlineMatch_disconnected)
+        OnlineMatch.match_left.connect(self._on_OnlineMatch_match_left)
+    else:
+        push_error("Can't find OnlineMatch singleton that the NakamaWebRTCNetworkAdaptor depends on!")
 
 func detach_network_adaptor(sync_manager) -> void:
-	if OnlineMatch:
-		OnlineMatch.webrtc_peer_added.disconnect(self._on_OnlineMatch_webrtc_peer_added)
-		OnlineMatch.webrtc_peer_removed.disconnect(self._on_OnlineMatch_webrtc_peer_removed)
-		OnlineMatch.disconnected.disconnect(self._on_OnlineMatch_disconnected)
-		OnlineMatch.match_left.disconnect(self._on_OnlineMatch_match_left)
+    if OnlineMatch:
+        OnlineMatch.webrtc_peer_added.disconnect(self._on_OnlineMatch_webrtc_peer_added)
+        OnlineMatch.webrtc_peer_removed.disconnect(self._on_OnlineMatch_webrtc_peer_removed)
+        OnlineMatch.disconnected.disconnect(self._on_OnlineMatch_disconnected)
+        OnlineMatch.match_left.disconnect(self._on_OnlineMatch_match_left)
 
 func start_network_adaptor(sync_manager) -> void:
-	_last_messages.clear()
-	_last_skipped_tick = 0
-	_skipped_tick_count = 0
+    _last_messages.clear()
+    _last_skipped_tick = 0
+    _skipped_tick_count = 0
 
 func stop_network_adaptor(sync_manager) -> void:
-	pass
+    pass
 
 func _on_OnlineMatch_webrtc_peer_added(webrtc_peer: WebRTCPeerConnection, player: OnlineMatch.Player) -> void:
-	print ("Peer added -- trying to re-establish the data channel")
+    print ("Peer added -- trying to re-establish the data channel")
 
-	var peer_id := player.peer_id
+    var peer_id := player.peer_id
 
-	if _data_channels.has(peer_id):
-		_data_channels.erase(peer_id)
+    if _data_channels.has(peer_id):
+        _data_channels.erase(peer_id)
 
-	var data_channel = webrtc_peer.create_data_channel('SyncManager', {
-		negotiated = true,
-		id = DATA_CHANNEL_ID,
-		maxPacketLifeTime = max_packet_lifetime,
-		ordered = false,
-	})
-	# data_channel can be null if the peer has disconnected
-	if data_channel != null:
-		data_channel.write_mode = WebRTCDataChannel.WRITE_MODE_BINARY
-		_data_channels[peer_id] = data_channel
+    var data_channel = webrtc_peer.create_data_channel('SyncManager', {
+        negotiated = true,
+        id = DATA_CHANNEL_ID,
+        maxPacketLifeTime = max_packet_lifetime,
+        ordered = false,
+    })
+    # data_channel can be null if the peer has disconnected
+    if data_channel != null:
+        data_channel.write_mode = WebRTCDataChannel.WRITE_MODE_BINARY
+        _data_channels[peer_id] = data_channel
 
-		if SyncManager._logger:
-			SyncManager._logger.data['nakama_webrtc_data_channel_created_for_peer_%s' % peer_id] = true
+        if SyncManager._logger:
+            SyncManager._logger.data['nakama_webrtc_data_channel_created_for_peer_%s' % peer_id] = true
 
 func _on_OnlineMatch_webrtc_peer_removed(webrtc_peer: WebRTCPeerConnection, player: OnlineMatch.Player) -> void:
-	var peer_id := player.peer_id
-	if _data_channels.has(peer_id):
-		# Can this cause problems with re-establishing the connection?
-		#_data_channels[peer_id].close()
-		_data_channels.erase(peer_id)
+    var peer_id := player.peer_id
+    if _data_channels.has(peer_id):
+        # Can this cause problems with re-establishing the connection?
+        #_data_channels[peer_id].close()
+        _data_channels.erase(peer_id)
 
 func _on_OnlineMatch_disconnected() -> void:
-	_data_channels.clear()
+    _data_channels.clear()
 
 func _on_OnlineMatch_match_left() -> void:
-	_data_channels.clear()
+    _data_channels.clear()
 
 func send_input_tick(peer_id: int, msg: PackedByteArray) -> void:
-	if _data_channels.has(peer_id) and _data_channels[peer_id].get_ready_state() == WebRTCDataChannel.STATE_OPEN:
-		var data_channel: WebRTCDataChannel = _data_channels[peer_id]
+    if _data_channels.has(peer_id) and _data_channels[peer_id].get_ready_state() == WebRTCDataChannel.STATE_OPEN:
+        var data_channel: WebRTCDataChannel = _data_channels[peer_id]
 
-		# Skip sending if the data channel is over the max buffered amount.
-		# Assuming the max_buffered_amount value is well tuned, this will kick
-		# in when SCTP's flow control turns on, and we want to wait until it
-		# turns back off before sending any more data.
-		if max_buffered_amount > 0 and data_channel.get_buffered_amount() > max_buffered_amount:
-			if _last_skipped_tick == SyncManager.current_tick:
-				# We don't need to output the message multiple times per tick.
-				return
+        # Skip sending if the data channel is over the max buffered amount.
+        # Assuming the max_buffered_amount value is well tuned, this will kick
+        # in when SCTP's flow control turns on, and we want to wait until it
+        # turns back off before sending any more data.
+        if max_buffered_amount > 0 and data_channel.get_buffered_amount() > max_buffered_amount:
+            if _last_skipped_tick == SyncManager.current_tick:
+                # We don't need to output the message multiple times per tick.
+                return
 
-			if _last_skipped_tick == SyncManager.current_tick - 1:
-				_skipped_tick_count += 1
-			else:
-				_skipped_tick_count = 0
+            if _last_skipped_tick == SyncManager.current_tick - 1:
+                _skipped_tick_count += 1
+            else:
+                _skipped_tick_count = 0
 
-			if _skipped_tick_count < max_skipped_input_in_a_row:
-				print ("[%s] Skipping send because buffer is too full (%s bytes)" % [SyncManager.current_tick, data_channel.get_buffered_amount()])
-				if SyncManager._logger:
-					SyncManager._logger.data['nakama_webrtc_send_skipped_to_peer_%s' % peer_id] = "Skipping send because buffer is too full (%s bytes)" % data_channel.get_buffered_amount()
-				_last_skipped_tick = SyncManager.current_tick
-				return
-			else:
-				_skipped_tick_count = 0
+            if _skipped_tick_count < max_skipped_input_in_a_row:
+                print ("[%s] Skipping send because buffer is too full (%s bytes)" % [SyncManager.current_tick, data_channel.get_buffered_amount()])
+                if SyncManager._logger:
+                    SyncManager._logger.data['nakama_webrtc_send_skipped_to_peer_%s' % peer_id] = "Skipping send because buffer is too full (%s bytes)" % data_channel.get_buffered_amount()
+                _last_skipped_tick = SyncManager.current_tick
+                return
+            else:
+                _skipped_tick_count = 0
 
-		if not _last_messages.has(peer_id):
-			_last_messages[peer_id] = []
-		var last_messages_for_peer = _last_messages[peer_id]
+        if not _last_messages.has(peer_id):
+            _last_messages[peer_id] = []
+        var last_messages_for_peer = _last_messages[peer_id]
 
-		# Clear out expired duplicate message records.
-		var current_time = Time.get_ticks_msec()
-		while last_messages_for_peer.size() > 0:
-			if current_time - last_messages_for_peer[0].time >= max_duplicate_msecs:
-				#print ("[%s] Retiring duplicate from duplicate message history" % [SyncManager.current_tick])
-				last_messages_for_peer.pop_front()
-			else:
-				break
+        # Clear out expired duplicate message records.
+        var current_time = Time.get_ticks_msec()
+        while last_messages_for_peer.size() > 0:
+            if current_time - last_messages_for_peer[0].time >= max_duplicate_msecs:
+                #print ("[%s] Retiring duplicate from duplicate message history" % [SyncManager.current_tick])
+                last_messages_for_peer.pop_front()
+            else:
+                break
 
-		# Avoid sending duplicate messages. We'll let WebRTC's reliability
-		# layer deal with making sure the message arrives, otherwise we can run
-		# afoul of SCTP's flow control algorithm.
-		var msg_hash_value = hash(msg)
-		for msg_hash in last_messages_for_peer:
-			if msg_hash.value == msg_hash_value:
-				print ("[%s] Skipping duplicate message" % [SyncManager.current_tick])
-				if SyncManager._logger:
-					SyncManager._logger.increment_value("nakama_webrtc_skipping_duplicate_messages_for_%s" % peer_id)
-				return
+        # Avoid sending duplicate messages. We'll let WebRTC's reliability
+        # layer deal with making sure the message arrives, otherwise we can run
+        # afoul of SCTP's flow control algorithm.
+        var msg_hash_value = hash(msg)
+        for msg_hash in last_messages_for_peer:
+            if msg_hash.value == msg_hash_value:
+                print ("[%s] Skipping duplicate message" % [SyncManager.current_tick])
+                if SyncManager._logger:
+                    SyncManager._logger.increment_value("nakama_webrtc_skipping_duplicate_messages_for_%s" % peer_id)
+                return
 
-		data_channel.put_packet(msg)
+        data_channel.put_packet(msg)
 
-		# Add message hash to duplicate history and push out old messages.
-		#last_messages_for_peer.append(MessageHash.new(msg_hash_value, current_time))
-		_last_messages[peer_id].append(MessageHash.new(msg_hash_value, current_time))
-		while last_messages_for_peer.size() > max_duplicate_history:
-			last_messages_for_peer.pop_front()
+        # Add message hash to duplicate history and push out old messages.
+        #last_messages_for_peer.append(MessageHash.new(msg_hash_value, current_time))
+        _last_messages[peer_id].append(MessageHash.new(msg_hash_value, current_time))
+        while last_messages_for_peer.size() > max_duplicate_history:
+            last_messages_for_peer.pop_front()
 
 func poll() -> void:
-	for peer_id in _data_channels:
-		var data_channel: WebRTCDataChannel = _data_channels[peer_id]
-		var data_channel_state = data_channel.get_ready_state()
-		if data_channel_state != WebRTCDataChannel.STATE_OPEN:
-			# Attempt to reconnect the data channel, if necessary.
-			if data_channel_state != WebRTCDataChannel.STATE_CONNECTING:
-				var player = OnlineMatch.get_player_by_peer_id(peer_id)
-				var webrtc_peer = OnlineMatch.get_webrtc_peer(player.session_id)
-				_on_OnlineMatch_webrtc_peer_added(webrtc_peer, player)
-			continue
+    for peer_id in _data_channels:
+        var data_channel: WebRTCDataChannel = _data_channels[peer_id]
+        var data_channel_state = data_channel.get_ready_state()
+        if data_channel_state != WebRTCDataChannel.STATE_OPEN:
+            # Attempt to reconnect the data channel, if necessary.
+            if data_channel_state != WebRTCDataChannel.STATE_CONNECTING:
+                var player = OnlineMatch.get_player_by_peer_id(peer_id)
+                var webrtc_peer = OnlineMatch.get_webrtc_peer(player.session_id)
+                _on_OnlineMatch_webrtc_peer_added(webrtc_peer, player)
+            continue
 
-		data_channel.poll()
+        data_channel.poll()
 
-		# Get all received messages.
-		while data_channel.get_available_packet_count() > 0:
-			var msg = data_channel.get_packet()
-			received_input_tick.emit(peer_id, msg)
+        # Get all received messages.
+        while data_channel.get_available_packet_count() > 0:
+            var msg = data_channel.get_packet()
+            received_input_tick.emit(peer_id, msg)

--- a/game/addons/godot-rollback-netcode/NetworkAdaptor.gd
+++ b/game/addons/godot-rollback-netcode/NetworkAdaptor.gd
@@ -18,7 +18,7 @@ static func is_type(obj: Object):
 signal received_ping (peer_id, msg)
 signal received_ping_back (peer_id, msg)
 signal received_remote_start ()
-signal received_remote_stop ()
+signal received_remote_stop (reason: Disconnect.Reason)
 signal received_input_tick (peer_id, msg)
 
 func attach_network_adaptor(sync_manager) -> void:
@@ -42,7 +42,7 @@ func send_ping_back(peer_id: int, msg: Dictionary) -> void:
 func send_remote_start(peer_id: int) -> void:
     push_error("UNIMPLEMENTED ERROR: NetworkAdaptor.send_remote_start()")
 
-func send_remote_stop(peer_id: int) -> void:
+func send_remote_stop(peer_id: int, reason: Disconnect.Reason = Disconnect.Reason.UNKNOWN) -> void:
     push_error("UNIMPLEMENTED ERROR: NetworkAdaptor.send_remote_stop()")
 
 func send_input_tick(peer_id: int, msg: PackedByteArray) -> void:

--- a/game/addons/godot-rollback-netcode/NetworkTimer.gd
+++ b/game/addons/godot-rollback-netcode/NetworkTimer.gd
@@ -31,7 +31,7 @@ func stop():
     _running = false
     ticks_left = 0
 
-func _on_SyncManager_sync_stopped() -> void:
+func _on_SyncManager_sync_stopped(_reason: Disconnect.Reason) -> void:
     stop()
 
 func _network_process(_input: Dictionary) -> void:

--- a/game/addons/godot-rollback-netcode/RPCNetworkAdaptor.gd
+++ b/game/addons/godot-rollback-netcode/RPCNetworkAdaptor.gd
@@ -23,12 +23,12 @@ func send_remote_start(peer_id: int) -> void:
 func _remote_start() -> void:
     received_remote_start.emit()
 
-func send_remote_stop(peer_id: int) -> void:
-    _remote_stop.rpc_id(peer_id)
+func send_remote_stop(peer_id: int, reason: Disconnect.Reason = Disconnect.Reason.UNKNOWN) -> void:
+    _remote_stop.rpc_id(peer_id, reason)
 
 @rpc("any_peer")
-func _remote_stop() -> void:
-    received_remote_stop.emit()
+func _remote_stop(reason: Disconnect.Reason = Disconnect.Reason.UNKNOWN) -> void:
+    received_remote_stop.emit(reason)
 
 func send_input_tick(peer_id: int, msg: PackedByteArray) -> void:
     _rit.rpc_id(peer_id, msg)

--- a/game/addons/godot-rollback-netcode/SoundManager.gd
+++ b/game/addons/godot-rollback-netcode/SoundManager.gd
@@ -53,5 +53,5 @@ func _on_audio_finished(node: Node) -> void:
 func _on_SyncManager_tick_retired(tick) -> void:
     ticks.erase(tick)
 
-func _on_SyncManager_sync_stopped() -> void:
+func _on_SyncManager_sync_stopped(_reason: Disconnect.Reason) -> void:
     ticks.clear()

--- a/game/network/Disconnect.gd
+++ b/game/network/Disconnect.gd
@@ -1,0 +1,6 @@
+class_name Disconnect
+
+enum Reason {
+    UNKNOWN = -1,
+    DESYNC = 0,
+}

--- a/game/network/main.gd
+++ b/game/network/main.gd
@@ -37,7 +37,6 @@ func _ready():
 
 func _disconnect_existing_peers() -> void:
     multiplayer.multiplayer_peer.close()
-    multiplayer.multiplayer_peer = null
 
 func _on_local_button_pressed():
     %Menu.hide()

--- a/game/network/main.gd
+++ b/game/network/main.gd
@@ -32,7 +32,12 @@ func _ready():
         $Menu/MarginContainer/VBoxContainer/JoinButton.hide()
     
     $Menu/MarginContainer/VBoxContainer/LocalButton.grab_focus.call_deferred()
-        
+    
+    _disconnect_existing_peers()
+
+func _disconnect_existing_peers() -> void:
+    multiplayer.multiplayer_peer.close()
+    multiplayer.multiplayer_peer = null
 
 func _on_local_button_pressed():
     %Menu.hide()
@@ -101,13 +106,11 @@ func add_player_and_start_game(id):
 
 @rpc("any_peer")
 func remove_player(id):
+    #_disconnect_existing_peers()
     #%Menu.show()
-    #if %MapInstance.get_child(0):
-        #%MapInstance.get_child(0).queue_free()
     pass
 
 func server_offline():
+    #_disconnect_existing_peers()
     #%Menu.show()
-    #if %MapInstance.get_child(0):
-        #%MapInstance.get_child(0).queue_free()
     pass

--- a/game/network/main.gd
+++ b/game/network/main.gd
@@ -101,11 +101,13 @@ func add_player_and_start_game(id):
 
 @rpc("any_peer")
 func remove_player(id):
-    %Menu.show()
-    if %MapInstance.get_child(0):
-        %MapInstance.get_child(0).queue_free()
+    #%Menu.show()
+    #if %MapInstance.get_child(0):
+        #%MapInstance.get_child(0).queue_free()
+    pass
 
 func server_offline():
-    %Menu.show()
-    if %MapInstance.get_child(0):
-        %MapInstance.get_child(0).queue_free()
+    #%Menu.show()
+    #if %MapInstance.get_child(0):
+        #%MapInstance.get_child(0).queue_free()
+    pass

--- a/game/network/main.gd
+++ b/game/network/main.gd
@@ -39,6 +39,8 @@ func _disconnect_existing_peers() -> void:
     multiplayer.multiplayer_peer.close()
 
 func _on_local_button_pressed():
+    multiplayer.multiplayer_peer = OfflineMultiplayerPeer.new()
+    
     %Menu.hide()
     load_game(1, 1)
 
@@ -90,14 +92,12 @@ func load_game(p1_id = 1, p2_id = 0):
         p2_id = multiplayer.get_unique_id()
     
     %Menu.hide()
-    if %MapInstance.get_children().size() > 0 && %MapInstance.get_child(0):
-        %MapInstance.get_child(0).queue_free()
     
     var instantiated_map = map.instantiate()
     instantiated_map.init_options(options)
     instantiated_map.p1_network_id = p1_id
     instantiated_map.p2_network_id = p2_id
-    %MapInstance.add_child(instantiated_map)
+    SceneSwitchUtil.change_scene(get_tree(), instantiated_map)
 
 func add_player_and_start_game(id):
     player_2_id = id

--- a/game/player/Player.gd
+++ b/game/player/Player.gd
@@ -245,7 +245,7 @@ func _save_state() -> Dictionary:
         't': team,
         'pi': previous_input,
         'c': character,
-        'hp': randi_range(0, 100),#health,
+        'hp': health,
         's': status,
         'fs': fsm.state,
         'ft': fsm.ticks_in_state,

--- a/game/player/Player.gd
+++ b/game/player/Player.gd
@@ -245,7 +245,7 @@ func _save_state() -> Dictionary:
         't': team,
         'pi': previous_input,
         'c': character,
-        'hp': health,
+        'hp': randi_range(0, 100),#health,
         's': status,
         'fs': fsm.state,
         'ft': fsm.ticks_in_state,

--- a/game/project.godot
+++ b/game/project.godot
@@ -63,7 +63,6 @@ rollback/spawn_manager/reuse_despawned_nodes=true
 rollback/classes/network_adaptor="res://addons/godot-rollback-netcode/RPCNetworkAdaptor.gd"
 rollback/classes/message_serializer="res://network/VsMessageSerializer.gd"
 rollback/classes/hash_serializer="res://addons/godot-rollback-netcode/HashSerializer.gd"
-rollback/debug/rollback_ticks=2
 
 [rendering]
 

--- a/game/project.godot
+++ b/game/project.godot
@@ -63,7 +63,8 @@ rollback/spawn_manager/reuse_despawned_nodes=true
 rollback/classes/network_adaptor="res://addons/godot-rollback-netcode/RPCNetworkAdaptor.gd"
 rollback/classes/message_serializer="res://network/VsMessageSerializer.gd"
 rollback/classes/hash_serializer="res://addons/godot-rollback-netcode/HashSerializer.gd"
-rollback/debug/check_local_state_consistency=true
+rollback/debug/rollback_ticks=2
+rollback/debug/random_rollback_ticks=2
 
 [rendering]
 

--- a/game/project.godot
+++ b/game/project.godot
@@ -64,7 +64,6 @@ rollback/classes/network_adaptor="res://addons/godot-rollback-netcode/RPCNetwork
 rollback/classes/message_serializer="res://network/VsMessageSerializer.gd"
 rollback/classes/hash_serializer="res://addons/godot-rollback-netcode/HashSerializer.gd"
 rollback/debug/rollback_ticks=2
-rollback/debug/random_rollback_ticks=2
 
 [rendering]
 

--- a/game/ui/menu/Notification.gd
+++ b/game/ui/menu/Notification.gd
@@ -1,0 +1,18 @@
+class_name Notification extends Control
+
+const ERROR_TITLE: String = "%s ERROR"
+
+@onready var notification_confirmed: Signal = $MC/VB/Confirm.pressed
+
+@onready var title: Label = $MC/VB/Title
+@onready var message: Label = $MC/VB/PC/MC/Message
+
+func notify_error(error_type: String, new_message: String) -> Signal:
+    title.text = ERROR_TITLE % error_type
+    message.text = new_message
+
+    show()
+    return notification_confirmed
+
+func _on_confirmed() -> void:
+    hide()

--- a/game/ui/menu/Notification.tscn
+++ b/game/ui/menu/Notification.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=3 format=3 uid="uid://bdy1yk1bvbqwg"]
+
+[ext_resource type="Theme" uid="uid://djk0g414gh3b4" path="res://ui/themes/NotificationTheme.tres" id="1_3bsv4"]
+[ext_resource type="Script" path="res://ui/menu/Notification.gd" id="2_wtulu"]
+
+[node name="Notification" type="PanelContainer"]
+theme = ExtResource("1_3bsv4")
+script = ExtResource("2_wtulu")
+
+[node name="MC" type="MarginContainer" parent="."]
+layout_mode = 2
+
+[node name="VB" type="VBoxContainer" parent="MC"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="MC/VB"]
+layout_mode = 2
+text = "Notification"
+horizontal_alignment = 1
+
+[node name="PC" type="PanelContainer" parent="MC/VB"]
+layout_mode = 2
+
+[node name="MC" type="MarginContainer" parent="MC/VB/PC"]
+layout_mode = 2
+
+[node name="Message" type="Label" parent="MC/VB/PC/MC"]
+layout_mode = 2
+text = "A notification is being displayed to the user.
+Please take appropriate action."
+
+[node name="Confirm" type="Button" parent="MC/VB"]
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Okay"

--- a/game/ui/themes/NotificationTheme.tres
+++ b/game/ui/themes/NotificationTheme.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Theme" format=3 uid="uid://djk0g414gh3b4"]
+
+[resource]
+MarginContainer/constants/margin_bottom = 4
+MarginContainer/constants/margin_left = 4
+MarginContainer/constants/margin_right = 4
+MarginContainer/constants/margin_top = 4


### PR DESCRIPTION
The main goal of this is to gracefully handle desynchronization & peer disconnection.

Players should be able to continue after failure without having to restart the game, basically. 

This also introduces some small changes to how the game manages its scenes. The main menu & gameplay scenes are now separate, and a static utility can help switch between them as needed.

I did hack some extra functionality onto the rollback addon in this PR. You're now able to supply a reason for calling a remote `stop()` on other rollback peers. Without this, it was difficult to provide consistent messaging for both clients when failures occurred.

If there was a state mismatch & the "host" peer detected it first, they might tell the other peers to stop before they detected a state mismatch on their own. This kind of race condition is probably most likely to happen in my local testing environment (where networking communication is near-instant) but it seems like good practice in general - other kinds of signalling could be useful down the line if we want to clarify other reasons for stopping the sync.