### PR TITLE
Save input mapping

### DIFF
--- a/game/network/main.gd
+++ b/game/network/main.gd
@@ -8,7 +8,7 @@ var player_2_id: int
 func _ready():
     InputMappingManager.load_all_mappings(_load_local_data("input_mapping.dat"))
     
-    $InputRemapperDisplay.confirmed.connect(_on_remapper_display_confirmed)
+    $InputRemapperDisplay.done.connect(_on_remapper_display_confirmed)
     $InputRemapperDisplay.redo.connect(_on_remap_button_pressed)
     
     $InputMapperLogic.waiting_for_next_input.connect($InputRemapperDisplay._on_waiting_for_next_input)
@@ -53,6 +53,7 @@ func _on_match_options_pressed():
 func _on_match_options_closed():
     $Menu.show()
     $MatchOptionsMenu.hide()
+    $"%MatchOptionsButton".grab_focus.call_deferred()
 
 func _on_remap_button_pressed(side: Player.Side):
     $Menu.hide()
@@ -62,12 +63,16 @@ func _on_remap_button_pressed(side: Player.Side):
     elif side == Player.Side.P2:
         InputMappingManager.p2_input_mapping = await $InputMapperLogic.collect_input_mapping()
 
-func _on_remapper_display_confirmed():
+func _on_remapper_display_confirmed(side: Player.Side):
     # save input config locally
     _save_local_data(InputMappingManager.get_all_mappings(), "input_mapping.dat")
     $InputRemapperDisplay.hide()
     $Menu.show()
-    $"Menu/MarginContainer/VBoxContainer/Remap P1 Input".grab_focus.call_deferred()
+    match side:
+        Player.Side.P1:
+            $"Menu/MarginContainer/VBoxContainer/Remap P1 Input".grab_focus.call_deferred()
+        Player.Side.P2:
+            $"Menu/MarginContainer/VBoxContainer/Remap P2 Input".grab_focus.call_deferred()
 
 func _save_local_data(data, filepath: String) -> void:
     var file = FileAccess.open("user://%s" % filepath, FileAccess.WRITE)

--- a/game/network/main.gd
+++ b/game/network/main.gd
@@ -6,6 +6,8 @@ var player_2_id: int
 
 # Port mapping for online multiplayer
 func _ready():
+    InputMappingManager.load_all_mappings(_load_local_data("input_mapping.dat"))
+    
     $InputRemapperDisplay.confirmed.connect(_on_remapper_display_confirmed)
     $InputRemapperDisplay.redo.connect(_on_remap_button_pressed)
     
@@ -61,9 +63,23 @@ func _on_remap_button_pressed(side: Player.Side):
         InputMappingManager.p2_input_mapping = await $InputMapperLogic.collect_input_mapping()
 
 func _on_remapper_display_confirmed():
+    # save input config locally
+    _save_local_data(InputMappingManager.get_all_mappings(), "input_mapping.dat")
     $InputRemapperDisplay.hide()
     $Menu.show()
     $"Menu/MarginContainer/VBoxContainer/Remap P1 Input".grab_focus.call_deferred()
+
+func _save_local_data(data, filepath: String) -> void:
+    var file = FileAccess.open("user://%s" % filepath, FileAccess.WRITE)
+    file.store_buffer(var_to_bytes(data))
+    file.close()
+
+func _load_local_data(filepath: String):
+    var raw_bytes = FileAccess.get_file_as_bytes("user://%s" % filepath)
+    if not raw_bytes.is_empty():
+        return bytes_to_var(raw_bytes)
+    else:
+        return null
 
 # Server
 func _on_host_button_pressed():

--- a/game/options/InputMappingManager.gd
+++ b/game/options/InputMappingManager.gd
@@ -3,3 +3,14 @@ class_name InputMappingManager extends RefCounted
 
 static var p1_input_mapping = InputRetriever.DEFAULT_P1
 static var p2_input_mapping = InputRetriever.DEFAULT_P2
+
+static func get_all_mappings() -> Dictionary:
+    return {
+        "p1": p1_input_mapping,
+        "p2": p2_input_mapping,
+    }
+
+static func load_all_mappings(mappings) -> void:
+    if typeof(mappings) == TYPE_DICTIONARY:
+        p1_input_mapping = mappings["p1"]
+        p2_input_mapping = mappings["p2"]

--- a/game/options/InputRemapperDisplay.gd
+++ b/game/options/InputRemapperDisplay.gd
@@ -1,5 +1,6 @@
 class_name InputRemapperDisplay extends Control
 
+signal done
 signal redo
 
 @export var highlight_color = Color(Color.GREEN, .5)
@@ -8,13 +9,12 @@ signal redo
 @onready var confirm_button: Button = $VBoxContainer/HBoxContainer/Confirm
 @onready var redo_button: Button = $VBoxContainer/HBoxContainer/Redo
 
-@onready var confirmed: Signal = confirm_button.pressed
-
 var current_side: Player.Side
 var action_input_pairs_mapped: Dictionary
 var selected_action_input_pair: ActionInputPair
 
 func _ready() -> void:
+    confirm_button.pressed.connect(_on_confirm_pressed)
     redo_button.pressed.connect(_on_redo_pressed)
     
     action_input_pairs_mapped = {}
@@ -53,6 +53,9 @@ func _on_remap_complete(_complete_input_map) -> void:
     confirm_button.disabled = false
     redo_button.disabled = false
     confirm_button.grab_focus.call_deferred()
+
+func _on_confirm_pressed():
+    done.emit(current_side)
 
 func _on_redo_pressed():
     redo.emit(current_side)


### PR DESCRIPTION
Use godot's api for local storage to save input configuration whenever it's written. 

The files are loaded every time the main menu is, which is fine. There's no way to update inputs in a way that doesn't save them, after all. 

There might be situations where this isn't good, but it seems like an okay starting point.

Also fixed a couple issues with what ui element was assigned focus when transitioning between menus.