### PR TITLE
Input refactor

### DIFF
--- a/game/assets/data/states/character/speed/MediumAttackState.tres
+++ b/game/assets/data/states/character/speed/MediumAttackState.tres
@@ -98,10 +98,10 @@ params = [ExtResource("8_6l1vh")]
 [resource]
 script = ExtResource("6_t00mo")
 stateId = 3
-expirationStateId = null
+expirationStateId = 0
 phases = Array[ExtResource("1_pivfc")]([SubResource("Resource_mmymt"), SubResource("Resource_0q5cg"), SubResource("Resource_21ysp"), SubResource("Resource_64fi3")])
 transition_in_effects = Array[ExtResource("2_ng3ut")]([SubResource("Resource_jam7s"), SubResource("Resource_vck4p")])
-transition_out_effects = null
+transition_out_effects = Array[ExtResource("2_ng3ut")]([])
 animation_key = "medium_attack"
-button_buffer_lookback = null
-consumes_button_buffer = null
+button_buffer_lookback = 8
+consumes_button_buffer = true

--- a/game/options/InputRemapperDisplay.tscn
+++ b/game/options/InputRemapperDisplay.tscn
@@ -36,6 +36,12 @@ layout_mode = 2
 [node name="ActionInputPair6" parent="VBoxContainer" groups=["action_input_pair"] instance=ExtResource("1_wkbd2")]
 layout_mode = 2
 
+[node name="ActionInputPair7" parent="VBoxContainer" groups=["action_input_pair"] instance=ExtResource("1_wkbd2")]
+layout_mode = 2
+
+[node name="ActionInputPair8" parent="VBoxContainer" groups=["action_input_pair"] instance=ExtResource("1_wkbd2")]
+layout_mode = 2
+
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4

--- a/game/player/Player.gd
+++ b/game/player/Player.gd
@@ -8,7 +8,6 @@ signal defeated
     # x
     # y
     # t - team (Side enum)
-    # pi - previous input (int, bitwise flags)
     # c - character (int, corresponds to enum)
     # hp - remaining health (int)
     # s - status (int, corresponds to enum)
@@ -59,7 +58,6 @@ var health: int
 var velocity: int
 var facing_direction: Side
 
-var previous_input: int
 var status: Status
 
 var hitstop_duration: int
@@ -265,7 +263,6 @@ func _save_state() -> Dictionary:
         'x': position.x,
         'y': position.y,
         't': team,
-        'pi': previous_input,
         'c': character,
         'hp': health,
         's': status,
@@ -290,7 +287,6 @@ func _load_state(state: Dictionary) -> void:
     position.x = state['x']
     position.y = state['y']
     team = state['t']
-    previous_input = state['pi']
     health = state['hp']
     status = state['s']
     hitstop_duration = state['hs']
@@ -375,7 +371,6 @@ func _network_spawn_preprocess(data: Dictionary) -> Dictionary:
     const spawn_combo_size = 0
     const spawn_velocity = 0
     const initial_attack_id = 0
-    data['pi'] = previous_input
     data['s'] = Status.NEUTRAL
     data['fs'] = State.IDLE
     data['ft'] = spawn_num_ticks_in_state

--- a/game/player/Player.gd
+++ b/game/player/Player.gd
@@ -318,16 +318,6 @@ func _load_state(state: Dictionary) -> void:
 func _get_local_input() -> Dictionary:
     return input_retriever.retrieve_input()
 
-func _process_input(new_input: Dictionary) -> Dictionary:
-    new_input = new_input.duplicate()
-    var previous_dict = InputHelper.to_dict(previous_input)
-    previous_input = InputHelper.to_int(new_input)
-    
-    # Turn actions in dictionary to "just pressed" values (will be 0 if held)
-    for input_key in input_action_keys:
-        new_input[input_key] = new_input[input_key] & (new_input[input_key] ^ previous_dict[input_key])
-    return new_input
-
 func _predict_remote_input(old_input: Dictionary, ticks_since_real_input: int) -> Dictionary:
     if ticks_since_real_input >= 5:
         return InputRetriever.EMPTY
@@ -336,8 +326,6 @@ func _predict_remote_input(old_input: Dictionary, ticks_since_real_input: int) -
 func _network_process(input: Dictionary):
     if input.is_empty():
         input = InputRetriever.EMPTY
-
-    input = _process_input(input)
 
     # add data to input buffer.
     action_buffer.push_frame(input)
@@ -361,7 +349,7 @@ func _network_process(input: Dictionary):
         counterhit_starter = false
 
 func _network_postprocess(input: Dictionary):
-    if status in [Status.STARTUP, Status.ACTIVE]:
+    if status in [Status.STARTUP, Status.ACTIVE, Status.VICTORY]:
         z_index = 1
     elif status in [Status.HITSTUN, Status.DEFEATED]:
         z_index = -1

--- a/game/player/fsm/effects/EffectLib.gd
+++ b/game/player/fsm/effects/EffectLib.gd
@@ -82,7 +82,7 @@ static func start_action(owner: Player, input_buffer: ActionBuffer, _ticks_in_st
     if attack_hit_required and not owner.attack_hit:
         return Player.State.NONE
     for key in input_to_state_mapping.keys():
-        if input_buffer.is_pressed(key):
+        if input_buffer.consume_just_pressed(key):
             return input_to_state_mapping[key]
     
     return Player.State.NONE

--- a/game/player/input/InputRetriever.gd
+++ b/game/player/input/InputRetriever.gd
@@ -1,7 +1,7 @@
 class_name InputRetriever extends RefCounted
 
-const INPUT_KEYS = ["l", "r", "a", "b", "c", "s"]
-const INPUT_FRIENDLY_NAMES = ["Left", "Right", "A", "B", "C", "Special"]
+const INPUT_KEYS = ["l", "r", "u", "d", "a", "b", "c", "s"]
+const INPUT_FRIENDLY_NAMES = ["Left", "Right", "Up", "Down", "A", "B", "C", "Special"]
 
 var control_type: ControlType = ControlType.KEYBOARD;
 var device_id: int = 0;
@@ -10,6 +10,8 @@ var input_ids: Dictionary = DEFAULT_P1 # could store a dictionary of callables i
 static var DEFAULT_P1 = {
     "l": [65], # A
     "r": [68], # D
+    "u": [87], # W
+    "d": [83], # S
     "a": [74], # J
     "b": [75], # K
     "c": [76], # L
@@ -19,6 +21,8 @@ static var DEFAULT_P1 = {
 static var DEFAULT_P2 = {
     "l": [90], # Z
     "r": [67], # C
+    "u": [86], # V
+    "d": [88], # X
     "a": [78], # N
     "b": [77], # M
     "c": [188], # ,
@@ -28,6 +32,8 @@ static var DEFAULT_P2 = {
 static var DEFAULT_CONTROLLER = {
     "l": [0, 13], # Z
     "r": [0, 14], # C
+    "u": [0, 11], 
+    "d": [0, 12],
     "a": [0, 2], # N
     "b": [0, 3], # M
     "c": [0, 10], # ,
@@ -37,6 +43,8 @@ static var DEFAULT_CONTROLLER = {
 static var DEFAULT_CONTROLLER_2 = {
     "l": [1, 13], # Z
     "r": [1, 14], # C
+    "u": [0, 11], 
+    "d": [0, 12],
     "a": [1, 2], # N
     "b": [1, 3], # M
     "c": [1, 10], # ,
@@ -46,6 +54,8 @@ static var DEFAULT_CONTROLLER_2 = {
 const EMPTY := {
     "l": 0,
     "r": 0,
+    "u": 0,
+    "d": 0,
     "a": 0,
     "b": 0,
     "c": 0,


### PR DESCRIPTION
Centralizes special input handling (like previous input tracking) in the input buffer.

This should make it easier to use the buffer to handle menus during rollback sync - they only want "just pressed" inputs for directionals, but the old system did some hacky split where it only tracked "just pressed" for "action" inputs.

Some naming might be less than ideal, but it's all okay.